### PR TITLE
Updated model.json to have processing option

### DIFF
--- a/autogen/README.md
+++ b/autogen/README.md
@@ -5,19 +5,21 @@ The Autogen framework gives 3 major file based interfaces for models: `model.jso
 `model.json` is a required configuration file shared between the Autogen Framework and the Autogen Tools. This covers both system-level properties as well as run-time tunable parameters for the model via registers.  
 `model.json` properties:  
 - `system`: An object to describe the overall system  
-    - `target`: Which hardware system is being targeted, the `audiomini` or `audioblade` (default: `audiomini`)  
-    - `sampleClockFrequency`: The sampling rate of the audio being processed (default: `48000`)  
-    - `systemClockFrequency`: Clock rate of the audio processing on the FPGA (default: `98304000`)  
-    - `inputDataType`: Object representing the data type of the audio input  
+    - `target`: Which hardware system is being targeted, the `audiomini` or `audioblade`
+    - `sampleClockFrequency`: The sampling rate of the audio being processed  
+    - `systemClockFrequency`: Clock rate of the audio processing on the FPGA 
+    - `processing`: Data processing format, either channel based ("channel") or sample based ("sample")
+    - `audioIn`: Object representing the data type of the audio input  
         - `wordLength`: number of total bits in the data type  
         - `fractionLength`: number of fractional bits in the fixed point number  
         - `signed`: true if the data type is signed, false otherwise  
-    - `outputDataType`: Object reprenting the data type of the audio output
+        - `numberOfChannels`: number of channels in the audio to be processed 
+    - `audioOut`: Object reprenting the data type of the audio output
     (Note: Currently unused, only inputDataType is read)
         - `wordLength`: number of total bits in the data type  
         - `fractionLength`: number of fractional bits in the fixed point number  
         - `signed`: true if the data type is signed, false otherwise  
-    - `numberOfChannels`: number of channels in the audio to be processed (default: `2`)  
+        - `numberOfChannels`: number of channels in the audio to be processed  
 - `devices`: An array of objects representing devices. Simulation support is only for one device.  
     - device object  
         - `name`: Name of the Simulink model  

--- a/autogen/configureModel.m
+++ b/autogen/configureModel.m
@@ -22,7 +22,7 @@ configPath = [modelPath filesep 'model.json'];
 config = jsondecode(fileread(configPath));
 
 mp.modelName = config.devices(1).name;
-
+mp.useAvalonInterface = lower(config.system.processing) == "channel";
 %% Set Audio Data
 
 mp.Fs = config.system.sampleClockFrequency; 

--- a/autogen/defaultModel.json
+++ b/autogen/defaultModel.json
@@ -3,7 +3,7 @@
         "target": "audiomini",
         "sampleClockFrequency": 48000,
         "systemClockFrequency": 98304000,
-        "processing": "channel"
+        "processing": "channel",
         "audioIn": {
             "wordLength": 24,
             "fractionLength": 23,

--- a/autogen/defaultModel.json
+++ b/autogen/defaultModel.json
@@ -3,7 +3,7 @@
         "target": "audiomini",
         "sampleClockFrequency": 48000,
         "systemClockFrequency": 98304000,
-
+        "processing": "channel"
         "audioIn": {
             "wordLength": 24,
             "fractionLength": 23,

--- a/autogen/initCallback.m
+++ b/autogen/initCallback.m
@@ -20,7 +20,7 @@
 
 % set to true so old models will still function if they don't override this
 % flag
-mp.useAvalonInterface = true;
+
 
 [modelPath,modelAbbreviation,~] = fileparts(which(bdroot));
 mp.modelPath = char(modelPath);

--- a/models/bitcrusher/model.json
+++ b/models/bitcrusher/model.json
@@ -3,7 +3,7 @@
         "target": "audiomini",
         "sampleClockFrequency": 48000,
         "systemClockFrequency": 98304000,
-
+        "processing": "channel",
         "audioIn": {
             "wordLength": 24,
             "fractionLength": 23,
@@ -20,7 +20,7 @@
 
     "devices": [
         {
-            "name": "bitcrusher",
+            "name": "BC",
             "registers": [
                 {
                     "dataType": {

--- a/models/echo/model.json
+++ b/models/echo/model.json
@@ -3,7 +3,7 @@
         "target": "audiomini",
         "sampleClockFrequency": 48000,
         "systemClockFrequency": 98304000,
-
+        "processing": "sample",
         "audioIn": {
             "wordLength": 24,
             "fractionLength": 23,
@@ -20,7 +20,7 @@
 
     "devices": [
         {
-            "name": "echo",
+            "name": "SE",
             "registers": [
                 {
                     "dataType": {


### PR DESCRIPTION
Updated for new avalon wrapper generation. That includes a processing field in the configuration and it is now mandatory for device name to match model name. Echo and Bitcrusher models have been updated

